### PR TITLE
Feature: namespace control

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,11 @@ std::unordered_map<int, SyscallRule> syscall_rule = {
     {1, SyscallRule(SyscallRuleType::ALLOW)},
 };
 
+// namespace rule
+NamespaceRule namespace_rule = NamespaceRule(false, false);
+
 // create Sandbox ruleset with default and specific rules
-SandboxRule sandbox_rule = SandboxRule(syscall_rule, default_rule);
+SandboxRule sandbox_rule = SandboxRule(syscall_rule, default_rule, namespace_rule=namespace_rule);
 ```
 
 ### Candbox execve

--- a/include/candbox/candbox.h
+++ b/include/candbox/candbox.h
@@ -15,14 +15,21 @@ struct ExecConfig {
     char **envp;
 };
 
+struct StackConfig {
+    void *stack_pointer;
+    size_t stack_size;
+};
+
 class Candbox {
 public:
     Candbox() = default;
-    void execve(ExecConfig const &config, SandboxRule const &SandboxRule);
+    void execve(ExecConfig const &config, SandboxRule const &SandboxRule, size_t stack_size);
 
 private:
-    void execve_child(ExecConfig const &config, SandboxRule const &sandbox_rule);
-    void trace(pid_t pid, SandboxRule const &sandbox_rule);
+    void execve_child(ExecConfig const &config, SandboxRule const &sandbox_rule,
+                      StackConfig const &StackConfig);
+    static int clone_child(void *);
+    void trace(pid_t pid, SandboxRule const &sandbox_rule, StackConfig const &StackConfig);
 };
 
 void trace_syscalls();

--- a/include/candbox/sandbox_rule.h
+++ b/include/candbox/sandbox_rule.h
@@ -22,6 +22,15 @@ public:
     const SyscallRuleType type() const { return _type; }
 };
 
+class NamespaceRule {
+    bool new_pid;
+    bool new_user;
+
+public:
+    NamespaceRule(bool new_pid, bool new_user) : new_pid(new_pid), new_user(new_user) {}
+    int get_clone_option();
+};
+
 class SandboxRule {
     /**
      * @brief Rules corresponding to syscalls
@@ -29,15 +38,20 @@ class SandboxRule {
      * corresponding rule
      */
     std::unordered_map<int, SyscallRule> syscall_rules;
-    SyscallRule _default_rule;
+    SyscallRule _default_syscall_rule;
+    NamespaceRule _namespace_rule;
 
 public:
     SandboxRule(std::unordered_map<int, SyscallRule> syscall_rules,
-                SyscallRule default_rule = SyscallRule(SyscallRuleType::DISALLOW))
-        : syscall_rules(syscall_rules), _default_rule(default_rule) {};
+                SyscallRule default_rule = SyscallRule(SyscallRuleType::DISALLOW),
+                NamespaceRule namespace_rule = NamespaceRule(false, false))
+        : syscall_rules(syscall_rules),
+          _default_syscall_rule(default_rule),
+          _namespace_rule(namespace_rule) {};
     const SyscallRule &get_sysrule(int syscall) const;
     const std::unordered_map<int, SyscallRule> &get_sysrule_map() const { return syscall_rules; };
-    const SyscallRule get_default_rule() const { return _default_rule; }
+    const SyscallRule get_default_syscall_rule() const { return _default_syscall_rule; }
+    const NamespaceRule get_namespace_rule() const { return _namespace_rule; }
 };
 
 };  // namespace candbox

--- a/src/candbox.cpp
+++ b/src/candbox.cpp
@@ -4,6 +4,7 @@
 #include <sched.h>
 #include <seccomp.h>
 #include <string.h>
+#include <sys/mman.h>
 #include <sys/prctl.h>
 #include <sys/ptrace.h>
 #include <sys/user.h>
@@ -19,7 +20,11 @@
 
 namespace candbox {
 
-void Candbox::execve(ExecConfig const &config, SandboxRule const &sandbox_rule) {
+void Candbox::execve(ExecConfig const &config, SandboxRule const &sandbox_rule,
+                     size_t stack_size = 1024 * 1024) {
+    void *stack = mmap(nullptr, stack_size, PROT_READ | PROT_WRITE | PROT_EXEC,
+                       MAP_ANONYMOUS | MAP_SHARED, -1, 0);
+    const StackConfig stack_config = {stack, stack_size};
     pid_t pid = fork();
     if (pid == -1) {  // fork fail
         throw std::runtime_error("fork failed");
@@ -27,43 +32,125 @@ void Candbox::execve(ExecConfig const &config, SandboxRule const &sandbox_rule) 
 
     if (pid == 0)  // child
     {
-        setpgid(0, 0);
-        execve_child(config, sandbox_rule);  // never return;
+        int result = setpgid(0, 0);
+        if (result < 0) exit(1);
+        execve_child(config, sandbox_rule, stack_config);  // never return;
     }
-    trace(pid, sandbox_rule);
+    return trace(pid, sandbox_rule, stack_config);
 }
 
-void Candbox::trace(pid_t tracee_pid, SandboxRule const &sandbox_rule) {
-    // checkout man page to get option information
-    // https://man7.org/linux/man-pages/man2/ptrace.2.html
+void Candbox::trace(pid_t delegate_pid, SandboxRule const &sandbox_rule,
+                    StackConfig const &stack_config) {
+    // this method is core of tracing child process
+    // there are two kind of traced processes
+    // 1. delegate process
+    // 2. child process (what we really want to trace)
+    // role of delegate process is setting context of proccess (at this point, the context is not
+    // yet applied) and fork process to child inherit and apply the context. After fork child,
+    // delegate process must be exited
 
+    // So, our logic resolve this step with very simple steps
+    // 1. fork to create delegate process (already done)
+    // 2. inject trace context to delegate process
+    // 3. delegate process configures additional context ifself (this is system call)
+    // step 3 needs system call so, tracer allow all syscalls
+    // 4. delegate fork to create child process, child process try execve syscall
+    // 5. tracer pass all delegate process fork until delegate is exited and stop child's execve
+    // event
+    // 6. tracer check delegate process is exited, continue child's exec event and trace all syscall
+    // until done
     int status;
     pid_t pid;
 
     // initialize ptrace option
     // After child ptrace_me, SIGSTOP on child -> parent wait SIGSTOP and set
     // option -> SIGCONT
-    pid = waitpid(tracee_pid, &status, WUNTRACED);
+    pid = waitpid(delegate_pid, &status, WUNTRACED);
     if (pid < 0) {
         return;
     }
 
-    auto option = PTRACE_O_EXITKILL | PTRACE_O_TRACECLONE | PTRACE_O_TRACEEXIT |
-                  PTRACE_O_TRACEFORK | PTRACE_O_TRACEVFORK | PTRACE_O_TRACESYSGOOD |
-                  PTRACE_O_TRACESECCOMP;
-    long result = ptrace(PTRACE_SETOPTIONS, tracee_pid, NULL, option);
-    if (result < 0)  // ptrace set option fail
     {
-        kill(tracee_pid, SIGKILL);
-        return;
-    } else  // set option success, continue
-    {
+        // checkout man page to get option information
+        // https://man7.org/linux/man-pages/man2/ptrace.2.html
+        auto option = PTRACE_O_EXITKILL | PTRACE_O_TRACECLONE | PTRACE_O_TRACEEXIT |
+                      PTRACE_O_TRACEEXEC | PTRACE_O_TRACEFORK | PTRACE_O_TRACEVFORK |
+                      PTRACE_O_TRACESYSGOOD | PTRACE_O_TRACESECCOMP;
+        long result = ptrace(PTRACE_SETOPTIONS, delegate_pid, NULL, option);
+        if (result < 0)  // ptrace set option fail
+        {
+            kill(delegate_pid, SIGKILL);
+            return;
+        }
+        // set option success, continue
         ptrace(PTRACE_CONT, pid, NULL, NULL);
     }
 
+    // find tracee and allow all ptrace event in delegate process
+    // delegate process set configure and clone execve with namespace setting
+    // delegate process create child process with clone + CLONE_PARENT so that
+    // child process can point parent process to this process
+    bool tracee_exists = false;
+    pid_t tracee_pid;
+    while (true) {
+        // only waiting delegate pid
+        int signal = 0;
+        pid = waitpid(delegate_pid, &status, __WALL);
+        if (pid == -1) {
+            break;
+        }
+        if (WSTOPSIG(status) == SIGTRAP) {
+            if (status >> 16 == PTRACE_EVENT_CLONE) {
+                unsigned long child_pid;
+                ptrace(PTRACE_GETEVENTMSG, pid, nullptr, &child_pid);
+                tracee_pid = static_cast<int>(child_pid);
+                tracee_exists = true;
+            }
+        }
+        ptrace(PTRACE_CONT, pid, NULL, signal);
+    }
+
+    if (!tracee_exists) {
+        return;
+    }
+
+    // allow all syscall and ptrace event until get EVENT_EXEC (EVENT EXEC occur after exec done)
+    // this work on single process so wait only tracee first
+    bool exec_exists = false;
     while (true) {
         int signal = 0;
-        pid = waitpid(-tracee_pid, &status, __WALL);
+        pid = waitpid(tracee_pid, &status, __WALL);
+        if (pid == -1) {
+            break;
+        }
+        if (WSTOPSIG(status) == SIGTRAP) {
+            if (status >> 16 == PTRACE_EVENT_EXEC) {
+                exec_exists = true;
+                break;
+            }
+        }
+        ptrace(PTRACE_CONT, pid, NULL, signal);
+    }
+    if (!exec_exists) {
+        return;
+    }
+
+    // we suspend PTRACE EVENT EXEC, so cont this event
+    ptrace(PTRACE_CONT, tracee_pid, NULL, 0);
+
+    // After exec, free child stack (see, clone stacksize)
+    int result = munmap(stack_config.stack_pointer, stack_config.stack_size);
+    if (result < 0) {
+        return;
+    }
+
+    // now we can trace all after execve
+    // we want to trace tracee and it's own childs so we trace group pid of tracee
+    // NOTE: delegate process already dead here
+    pid_t tracee_gpid = -delegate_pid;
+    while (true) {
+        int signal = 0;
+        pid = waitpid(tracee_gpid, &status, __WALL);
         if (pid == -1) {
             break;
         }
@@ -82,19 +169,18 @@ void Candbox::trace(pid_t tracee_pid, SandboxRule const &sandbox_rule) {
             ptrace(PTRACE_GET_SYSCALL_INFO, pid, sizeof(syscall_info), &syscall_info);
             int syscall_num = static_cast<int>(syscall_info.seccomp.nr);
 
-            bool is_disallow = false;
+            bool is_disallow = true;
             const SyscallRule &syscall_rule = sandbox_rule.get_sysrule(syscall_num);
             switch (syscall_rule.type()) {
                 case SyscallRuleType::ALLOW:
+                    is_disallow = false;
                     break;
                 case SyscallRuleType::DISALLOW:
-                    is_disallow = true;
                     break;
                 case SyscallRuleType::CALLBACK:
                     is_disallow = syscall_rule.callback(syscall_num);
                     break;
                 default:
-                    is_disallow = true;
                     break;
             }
             if (is_disallow) {
@@ -110,6 +196,7 @@ void Candbox::trace(pid_t tracee_pid, SandboxRule const &sandbox_rule) {
                         case (PTRACE_EVENT_FORK):
                         case (PTRACE_EVENT_VFORK):
                         case (PTRACE_EVENT_CLONE):
+                            break;
                         case (PTRACE_EVENT_EXEC):
                             break;
                         default:
@@ -126,7 +213,8 @@ void Candbox::trace(pid_t tracee_pid, SandboxRule const &sandbox_rule) {
     return;
 }
 
-void Candbox::execve_child(ExecConfig const &config, SandboxRule const &sandbox_rule) {
+void Candbox::execve_child(ExecConfig const &config, SandboxRule const &sandbox_rule,
+                           StackConfig const &stack_config) {
     // fork from Candbox::execv
     if (ptrace(PTRACE_TRACEME, 0, nullptr, nullptr)) {
         perror("tracee | ptrace trace failed");
@@ -168,6 +256,8 @@ void Candbox::execve_child(ExecConfig const &config, SandboxRule const &sandbox_
         }
     }
 
+    auto copy = config;
+    auto arg = static_cast<void *>(&copy);
     int rc = seccomp_load(ctx);
     if (rc < 0) {
         seccomp_release(ctx);
@@ -175,9 +265,31 @@ void Candbox::execve_child(ExecConfig const &config, SandboxRule const &sandbox_
     }
     seccomp_release(ctx);
 
-    ::execve(config.argv[0], config.argv, config.envp);
-    perror("tracee | execve failed\n");
-    exit(1);
+    void *stack_top_pointer = stack_config.stack_pointer + stack_config.stack_size;
+
+    NamespaceRule namespace_rule = sandbox_rule.get_namespace_rule();
+    int clone_option = namespace_rule.get_clone_option();
+    int pid = clone(Candbox::clone_child, stack_top_pointer, clone_option, arg);
+    if (pid < 0) exit(1);
+    exit(0);
 }
+
+int Candbox::clone_child(void *arg) {
+    ExecConfig &config = *static_cast<ExecConfig *>(arg);
+    ::execve(config.argv[0], config.argv, config.envp);
+    exit(1);
+    return 0;
+}
+
+int NamespaceRule::get_clone_option() {
+    int option = CLONE_PARENT;
+    if (new_pid) {
+        option |= CLONE_NEWPID;
+    }
+    if (new_user) {
+        option |= CLONE_NEWUSER;
+    }
+    return option;
+};
 
 };  // namespace candbox

--- a/src/syscall_rule.cpp
+++ b/src/syscall_rule.cpp
@@ -8,7 +8,7 @@ const SyscallRule &SandboxRule::get_sysrule(int syscall) const {
     auto rule = syscall_rules.find(syscall);
     if (rule == syscall_rules.end())  // no corresponding rule -> return default rule
     {
-        return _default_rule;
+        return _default_syscall_rule;
     } else {
         return rule->second;
     }


### PR DESCRIPTION
Feature
- namespace control
- NEW PID
- NEW USER

With clone syscall, control child process namespace is possible.
Tracer process fork child process and start trace. The child process that is created at this moment is called **delegate process**. Delegate process create permission context and clone it's child process (and this is tracee). Thanks to clone option CLONE_PARENT this child process can have parent process as tracer. So, Tracer ignore all trace from delegate process and trace only tracee.
